### PR TITLE
Update Node.js version to 22 for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   },
   "ct3aMetadata": {
     "initVersion": "7.12.1"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `engines.node: "22.x"` to `package.json` per Vercel's deprecation of Node.js 18 and its legacy build image
- Ensures builds use the latest Vercel build image and continue receiving security updates

## Test plan
- [ ] Verify Vercel deployment succeeds with Node.js 22
- [ ] Confirm site builds and runs correctly post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)